### PR TITLE
Sends current recipe ID for random selections

### DIFF
--- a/src/app/recipes.service.ts
+++ b/src/app/recipes.service.ts
@@ -16,8 +16,13 @@ export class RecipesService {
   public currentRecipe = this.recipe.asReadonly();
 
   setRandomRecipe(complexity: Complexity) {
+    // pass only the id string (or 'norecipe') to the backend
+    const currentId = this.currentRecipe()?.id ?? 'norecipe';
+
     const GETRECIPE = this.httpClient
-      .get<Recipe>(`http://localhost:3000/api/recipes/random/${complexity}`)
+      .get<Recipe>(`http://localhost:3000/api/recipes/random/${complexity}`, {
+        params: { id: currentId },
+      })
       .pipe(
         catchError((error) => {
           console.log(error);


### PR DESCRIPTION
Includes the active recipe's identifier as a query parameter when requesting a new random recipe. This allows the backend to exclude the current selection from its logic, ensuring users receive a different recommendation each time.